### PR TITLE
Add LastUpdated method to repos

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -233,6 +233,22 @@ func (r *Repo) getAllFiles() (map[string]*object.File, error) {
 	return files, nil
 }
 
+// LastUpdated returns the timestamp that the current checkoud out reference
+// was last updated
+func (r *Repo) LastUpdated() (time.Time, error) {
+	head, err := r.repository.Head()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unable to fetch repository head: %v", err)
+	}
+
+	commit, err := r.repository.CommitObject(head.Hash())
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unable to retrieve commit: %v", err)
+	}
+
+	return commit.Committer.When, nil
+}
+
 // Contents returns the content of a file
 func (f *File) Contents() string {
 	if f.file == nil {

--- a/repo_test.go
+++ b/repo_test.go
@@ -95,6 +95,14 @@ var _ = Describe("GitStore", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(changelog).To(BeNil())
 			})
+
+			It("Should be able to get the LastUpdated timestamp", func() {
+				lastUpdated, err := repo.LastUpdated()
+				Expect(err).ToNot(HaveOccurred())
+				utcPlus2 := time.FixedZone("+0200", int(2*time.Hour.Seconds()))
+				expectedTime := time.Date(2015, time.March, 31, 13, 42, 21, 0, utcPlus2)
+				Expect(lastUpdated).To(BeTemporally("==", expectedTime))
+			})
 		})
 
 		Context("and the eighth commit is checkout out", func() {
@@ -115,6 +123,14 @@ var _ = Describe("GitStore", func() {
 				foo, ok := files["vendor/foo.go"]
 				Expect(ok).To(BeTrue())
 				Expect(foo.Contents()).To(Equal(expectedFoo))
+			})
+
+			It("Should be able to get the LastUpdated timestamp", func() {
+				lastUpdated, err := repo.LastUpdated()
+				Expect(err).ToNot(HaveOccurred())
+				utcPlus2 := time.FixedZone("+0200", int(2*time.Hour.Seconds()))
+				expectedTime := time.Date(2015, time.April, 5, 23, 30, 47, 0, utcPlus2)
+				Expect(lastUpdated).To(BeTemporally("==", expectedTime))
 			})
 
 			var findsFiles = func(path string, count int) {


### PR DESCRIPTION
This will be used by faros to omit a metric for time from commit to deploy.

Finds the head commit and returns it's timestamp.

When merging into a branch this should be the merge commit (or maybe a squash commit), and so should represent the action of merge to deploy