### PR TITLE
Close channel only when repo is ready

### DIFF
--- a/store.go
+++ b/store.go
@@ -56,10 +56,19 @@ func (rs *RepoStore) GetAsync(ref *RepoRef) (*AsyncRepoCloner, <-chan struct{}, 
 	}
 
 	returnRC := func(rc *AsyncRepoCloner) (*AsyncRepoCloner, <-chan struct{}, error) {
-		rc.Repo.auth = auth
+		if rc.Repo != nil {
+			rc.Repo.auth = auth
+		}
 		glog.V(2).Infof("Reusing repository for %s", ref.URL)
 		c := make(chan struct{})
-		close(c)
+		go func() {
+			for {
+				if rc.Ready {
+					close(c)
+					return
+				}
+			}
+		}()
 		return rc, c, nil
 	}
 


### PR DESCRIPTION
The concurrency fix in #9 introduced some nil pointer dereferencing.

I've managed to fix this with the below changes.

Ran this on wercker in the faros test suite 14 times (using `-untilItFails` waiting for their 25 min timeout) so I'm pretty confident this has fixed the issue we were having