### PR TITLE
Wrap all calls to underlying repo in mutex locks

### DIFF
--- a/cloner.go
+++ b/cloner.go
@@ -35,11 +35,7 @@ func (rc *AsyncRepoCloner) Clone(auth transport.AuthMethod) <-chan struct{} {
 		if err != nil {
 			rc.Error = err
 		} else {
-			repo := &Repo{
-				auth:       auth,
-				repository: repository,
-			}
-			rc.Repo = repo
+			rc.Repo = newRepo(repository, auth)
 			rc.Ready = true
 		}
 		rc.mutex.Unlock()

--- a/store.go
+++ b/store.go
@@ -56,11 +56,9 @@ func (rs *RepoStore) GetAsync(ref *RepoRef) (*AsyncRepoCloner, <-chan struct{}, 
 	}
 
 	returnRC := func(rc *AsyncRepoCloner) (*AsyncRepoCloner, <-chan struct{}, error) {
-		rc.mutex.Lock()
 		if rc.Repo != nil {
-			rc.Repo.auth = auth
+			rc.Repo.setAuth(auth)
 		}
-		rc.mutex.Unlock()
 
 		glog.V(2).Infof("Reusing repository for %s", ref.URL)
 		c := make(chan struct{})


### PR DESCRIPTION
More data races in Faros revealed that the underlying git repository object is not thread safe.

This is an attempt to make our `Repo` thread safe by wrapping all calls the the underlying `*git.Repository` in mutex locks