### PR TITLE
Update go git

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -267,7 +267,7 @@
   version = "v4.2.0"
 
 [[projects]]
-  digest = "1:e0fabac30ae26530d84ebaefd95c62cbd280bb4176734913852cb1938bcc8610"
+  digest = "1:1ea7acba0f88007ecacda272a1414bffb529c2da8dbdac647139d2d1590d8354"
   name = "gopkg.in/src-d/go-git.v4"
   packages = [
     ".",
@@ -312,8 +312,8 @@
     "utils/merkletrie/noder",
   ]
   pruneopts = "UT"
-  revision = "3bd5e82b2512d85becae9677fa06b5a973fd4cfb"
-  version = "v4.5.0"
+  revision = "3dbfb89e0f5bce0008724e547b999fe3af9f60db"
+  version = "v4.8.1"
 
 [[projects]]
   branch = "v1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,7 +42,7 @@
 
 [[constraint]]
   name = "gopkg.in/src-d/go-git.v4"
-  version = "4.5.0"
+  version = "4.8.1"
 
 [[constraint]]
   name = "github.com/gobwas/glob"

--- a/repo.go
+++ b/repo.go
@@ -185,7 +185,9 @@ func (r *Repo) getBlame(path string) (*git.BlameResult, error) {
 
 	blame, err := git.Blame(commit, path)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch git blame: %v", err)
+		fmt.Printf("WARN: failed to fetch git blame: %v", err)
+		return &git.BlameResult{Lines: []*git.Line{}}, nil
+		//		return nil, fmt.Errorf("unable to fetch git blame: %v", err)
 	}
 	return blame, nil
 }

--- a/repo.go
+++ b/repo.go
@@ -187,7 +187,6 @@ func (r *Repo) getBlame(path string) (*git.BlameResult, error) {
 	if err != nil {
 		fmt.Printf("WARN: failed to fetch git blame: %v", err)
 		return &git.BlameResult{Lines: []*git.Line{}}, nil
-		//		return nil, fmt.Errorf("unable to fetch git blame: %v", err)
 	}
 	return blame, nil
 }


### PR DESCRIPTION
Updates go-git to most recent release and adds workaround for occasional failure to fetch git blame information observed in the wild.