### PR TITLE
Add IsFile and IsDirectory methods to Repo

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -297,6 +297,33 @@ func (r *Repo) getHeadCommit() (*object.Commit, error) {
 	return commit, nil
 }
 
+// IsDirectory checks if the reference at a path if a directory
+func (r *Repo) IsDirectory(path string) (bool, error) {
+	return r.isFileMode(path, filemode.Dir)
+}
+
+// IsFile checks if the reference at a path if a regular file
+func (r *Repo) IsFile(path string) (bool, error) {
+	return r.isFileMode(path, filemode.Regular)
+}
+
+func (r *Repo) isFileMode(path string, mode filemode.FileMode) (bool, error) {
+	commit, err := r.getHeadCommit()
+	if err != nil {
+		return false, fmt.Errorf("error fetching head commit: %v", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return false, fmt.Errorf("error fetching commit tree: %v", err)
+	}
+
+	entry, err := tree.FindEntry(path)
+	if err != nil {
+		return false, fmt.Errorf("error looking up path: %v", err)
+	}
+	return entry.Mode == mode, nil
+}
+
 // Contents returns the content of the File as a string.
 //
 // Note: Contents() does not verify file type and will return binary files as a (probably useless) string representation.

--- a/repo_test.go
+++ b/repo_test.go
@@ -141,6 +141,44 @@ var _ = Describe("GitStore", func() {
 				Expect(lastUpdated).To(BeTemporally("==", expectedTime))
 			})
 
+			Context("the IsFile method", func() {
+				It("Should correctly identify regular files", func() {
+					isFile, err := repo.IsFile("CHANGELOG")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(isFile).To(BeTrue())
+				})
+
+				It("Should correctly identify non-regular files", func() {
+					isFile, err := repo.IsFile("vendor")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(isFile).To(BeFalse())
+				})
+
+				It("Should throw an error if an invalid path is given", func() {
+					_, err := repo.IsFile("not-valid")
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("the IsDirectory method", func() {
+				It("Should correctly identify directories", func() {
+					isFile, err := repo.IsDirectory("vendor")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(isFile).To(BeTrue())
+				})
+
+				It("Should correctly identify non-directories", func() {
+					isFile, err := repo.IsDirectory("CHANGELOG")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(isFile).To(BeFalse())
+				})
+
+				It("Should throw an error if an invalid path is given", func() {
+					_, err := repo.IsDirectory("not-valid")
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
 			var findsFiles = func(path string, count int) {
 				It(fmt.Sprintf("Finds %d files inside path %s", count, path), func() {
 					files, err := repo.GetAllFiles(path, true)


### PR DESCRIPTION
This adds two methods to the GitStore that allow you to check ahead of time if a path within a repo is a directory or a file. This will allow you to take a path, check which case it matches, then attempt to load the single file or multiple files based on the output. 