### PR TITLE
Lazily load file log on request

### DIFF
--- a/repo_test.go
+++ b/repo_test.go
@@ -111,6 +111,18 @@ var _ = Describe("GitStore", func() {
 				expectedTime := time.Date(2015, time.March, 31, 13, 42, 21, 0, utcPlus2)
 				Expect(lastUpdated).To(BeTemporally("==", expectedTime))
 			})
+
+			It("Should be able to get blame information", func() {
+				license, _ := repo.GetFile("LICENSE")
+				log, err := license.FileLog()
+				Expect(err).To(BeNil())
+				utcPlus2 := time.FixedZone("+0200", int(2*time.Hour.Seconds()))
+				expectedTime := time.Date(2015, time.March, 31, 13, 42, 21, 0, utcPlus2)
+				Expect(log.Date).To(BeTemporally("==", expectedTime))
+				Expect(log.Hash.String()).To(Equal("b029517f6300c2da0f4b651b8642506cd6aaf45d"))
+				Expect(log.Author).To(Equal("mcuadros@gmail.com"))
+				Expect(log.Text).To(Equal("The MIT License (MIT)"))
+			})
 		})
 
 		Context("and the eighth commit is checkout out", func() {
@@ -139,6 +151,18 @@ var _ = Describe("GitStore", func() {
 				utcPlus2 := time.FixedZone("+0200", int(2*time.Hour.Seconds()))
 				expectedTime := time.Date(2015, time.April, 5, 23, 30, 47, 0, utcPlus2)
 				Expect(lastUpdated).To(BeTemporally("==", expectedTime))
+			})
+
+			It("Should be able to get blame information", func() {
+				foo, _ := repo.GetFile("vendor/foo.go")
+				log, err := foo.FileLog()
+				Expect(err).To(BeNil())
+				utcPlus2 := time.FixedZone("+0200", int(2*time.Hour.Seconds()))
+				expectedTime := time.Date(2015, time.April, 5, 23, 30, 47, 0, utcPlus2)
+				Expect(log.Date).To(BeTemporally("==", expectedTime))
+				Expect(log.Hash.String()).To(Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+				Expect(log.Author).To(Equal("mcuadros@gmail.com"))
+				Expect(log.Text).To(Equal("package main"))
 			})
 
 			Context("the IsFile method", func() {

--- a/repo_test.go
+++ b/repo_test.go
@@ -123,6 +123,21 @@ var _ = Describe("GitStore", func() {
 				Expect(log.Author).To(Equal("mcuadros@gmail.com"))
 				Expect(log.Text).To(Equal("The MIT License (MIT)"))
 			})
+
+			It("Should be able to get blame information from files returned by GetAllFiles", func() {
+				files, err := repo.GetAllFiles("", true)
+				Expect(err).To(BeNil())
+				license, ok := files["LICENSE"]
+				Expect(ok).To(BeTrue())
+				log, err := license.FileLog()
+				Expect(err).To(BeNil())
+				utcPlus2 := time.FixedZone("+0200", int(2*time.Hour.Seconds()))
+				expectedTime := time.Date(2015, time.March, 31, 13, 42, 21, 0, utcPlus2)
+				Expect(log.Date).To(BeTemporally("==", expectedTime))
+				Expect(log.Hash.String()).To(Equal("b029517f6300c2da0f4b651b8642506cd6aaf45d"))
+				Expect(log.Author).To(Equal("mcuadros@gmail.com"))
+				Expect(log.Text).To(Equal("The MIT License (MIT)"))
+			})
 		})
 
 		Context("and the eighth commit is checkout out", func() {
@@ -155,6 +170,21 @@ var _ = Describe("GitStore", func() {
 
 			It("Should be able to get blame information", func() {
 				foo, _ := repo.GetFile("vendor/foo.go")
+				log, err := foo.FileLog()
+				Expect(err).To(BeNil())
+				utcPlus2 := time.FixedZone("+0200", int(2*time.Hour.Seconds()))
+				expectedTime := time.Date(2015, time.April, 5, 23, 30, 47, 0, utcPlus2)
+				Expect(log.Date).To(BeTemporally("==", expectedTime))
+				Expect(log.Hash.String()).To(Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+				Expect(log.Author).To(Equal("mcuadros@gmail.com"))
+				Expect(log.Text).To(Equal("package main"))
+			})
+
+			It("Should be able to get blame information from files returned from GetAllFiles", func() {
+				files, err := repo.GetAllFiles("", true)
+				Expect(err).To(BeNil())
+				foo, ok := files["vendor/foo.go"]
+				Expect(ok).To(BeTrue())
 				log, err := foo.FileLog()
 				Expect(err).To(BeNil())
 				utcPlus2 := time.FixedZone("+0200", int(2*time.Hour.Seconds()))


### PR DESCRIPTION
Computing the file log for each file is quite expensive, so rather than doing it in Repo.GetAllFiles we're now doing it lazily when requested, which should cut down CPU usage in Faros (primarily) by about 50% (give
or take).