### PR TITLE
Add ability to clone files to the filesystem

### DIFF
--- a/cloner.go
+++ b/cloner.go
@@ -13,12 +13,12 @@ import (
 
 // AsyncRepoCloner provides an asynchronous repository cloner that can perform long-running checkout operations without blocking.
 type AsyncRepoCloner struct {
-	Ready    bool     // Ready indicates whether the clone operation has completed.
-	RepoRef  *RepoRef // RepoRef is a pointer to the RepoRef handled by this cloner.
-	Repo     *Repo    // Repo contains the actual repository once clone has completed.
-	Error    error    // Error is the last error encountered during the clone operation or nil.
-	repoPath string   // repoPath is the path to clone the repository into.
-	mutex    sync.Mutex
+	Ready   bool     // Ready indicates whether the clone operation has completed.
+	RepoRef *RepoRef // RepoRef is a pointer to the RepoRef handled by this cloner.
+	Repo    *Repo    // Repo contains the actual repository once clone has completed.
+	Error   error    // Error is the last error encountered during the clone operation or nil.
+	repoDir string   // repoDir is the path to clone the repository into.
+	mutex   sync.Mutex
 }
 
 // Clone starts an asynchronous clone of the requested repository and sets Ready to true when the repository is cloned successfully.
@@ -34,10 +34,10 @@ func (rc *AsyncRepoCloner) Clone(auth transport.AuthMethod) <-chan struct{} {
 
 		var err error
 		var repository *git.Repository
-		if rc.repoPath != "" {
-			repository, err = git.PlainClone(rc.repoPath, false, cloneOptions)
+		if rc.repoDir != "" {
+			repository, err = git.PlainClone(rc.repoDir, false, cloneOptions)
 		} else {
-			// No repoPath provided, default to in memory clone
+			// No repoDir provided, default to in memory clone
 			fs := memfs.New()
 			storer := memory.NewStorage()
 			repository, err = git.Clone(storer, fs, cloneOptions)

--- a/cloner_test.go
+++ b/cloner_test.go
@@ -11,7 +11,7 @@ var _ = Describe("GitStore", func() {
 	var rs *RepoStore
 
 	BeforeEach(func() {
-		rs = NewRepoStore()
+		rs = NewRepoStore("")
 	})
 
 	Context("when a new repo is cloned", func() {

--- a/repo_test.go
+++ b/repo_test.go
@@ -25,7 +25,7 @@ var _ = Describe("GitStore", func() {
 		var done <-chan struct{}
 
 		BeforeEach(func() {
-			rs = NewRepoStore()
+			rs = NewRepoStore("")
 			var err error
 			rc, done, err = rs.GetAsync(&RepoRef{
 				URL: repositoryURL,
@@ -49,7 +49,7 @@ var _ = Describe("GitStore", func() {
 		var repo *Repo
 
 		BeforeEach(func() {
-			rs = NewRepoStore()
+			rs = NewRepoStore("")
 			var err error
 			repo, err = rs.Get(&RepoRef{
 				URL: repositoryURL,

--- a/repo_test.go
+++ b/repo_test.go
@@ -2,6 +2,8 @@ package gitstore
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -19,37 +21,12 @@ func main() {
 
 var _ = Describe("GitStore", func() {
 
-	Context("When the repository is cloned asynchronously", func() {
-		var rs *RepoStore
-		var rc *AsyncRepoCloner
-		var done <-chan struct{}
-
-		BeforeEach(func() {
-			rs = NewRepoStore("")
-			var err error
-			rc, done, err = rs.GetAsync(&RepoRef{
-				URL: repositoryURL,
-			})
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(done, 5*time.Second).Should(BeClosed())
-			Expect(rc.Ready).To(BeTrue())
-			err = rc.Repo.Checkout("master")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(rc).ToNot(BeNil())
-		})
-
-		It("Should checkout the commit", func() {
-			err := rc.Repo.Checkout("b029517f6300c2da0f4b651b8642506cd6aaf45d")
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Context("When the git repository is cloned", func() {
+	RepositoryTests := func(path string) {
 		var rs *RepoStore
 		var repo *Repo
 
 		BeforeEach(func() {
-			rs = NewRepoStore("")
+			rs = NewRepoStore(path)
 			var err error
 			repo, err = rs.Get(&RepoRef{
 				URL: repositoryURL,
@@ -247,6 +224,51 @@ var _ = Describe("GitStore", func() {
 			findsFiles("json/*", 2)
 			findsFiles("vendor/*", 1)
 		})
+	}
 
+	Context("When the repository is cloned asynchronously", func() {
+		var rs *RepoStore
+		var rc *AsyncRepoCloner
+		var done <-chan struct{}
+
+		BeforeEach(func() {
+			rs = NewRepoStore("")
+			var err error
+			rc, done, err = rs.GetAsync(&RepoRef{
+				URL: repositoryURL,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(done, 5*time.Second).Should(BeClosed())
+			Expect(rc.Ready).To(BeTrue())
+			err = rc.Repo.Checkout("master")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rc).ToNot(BeNil())
+		})
+
+		It("Should checkout the commit", func() {
+			err := rc.Repo.Checkout("b029517f6300c2da0f4b651b8642506cd6aaf45d")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("When the git repository is cloned in memory", func() {
+		RepositoryTests("")
+	})
+
+	Context("When the git repository is cloned to a directory", func() {
+		var tmpDir string
+
+		BeforeEach(func() {
+			// Create a temp directory for each test
+			var err error
+			tmpDir, err = ioutil.TempDir("", "git-store")
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(tmpDir)
+		})
+
+		RepositoryTests(tmpDir)
 	})
 })

--- a/store.go
+++ b/store.go
@@ -34,15 +34,15 @@ var (
 type RepoStore struct {
 	repositories map[string]*AsyncRepoCloner
 	mutex        sync.RWMutex
-	repoPath     string
+	repoDir      string
 }
 
 // NewRepoStore initializes a new RepoStore.
-func NewRepoStore(repoPath string) *RepoStore {
+func NewRepoStore(repoDir string) *RepoStore {
 	return &RepoStore{
 		repositories: make(map[string]*AsyncRepoCloner),
 		mutex:        sync.RWMutex{},
-		repoPath:     repoPath,
+		repoDir:      repoDir,
 	}
 }
 
@@ -91,14 +91,14 @@ func (rs *RepoStore) GetAsync(ref *RepoRef) (*AsyncRepoCloner, <-chan struct{}, 
 		return returnRC(rc)
 	}
 
-	var repoPath string
-	if rs.repoPath != "" {
-		repoPath = path.Join(rs.repoPath, ref.URL)
+	var repoDir string
+	if rs.repoDir != "" {
+		repoDir = path.Join(rs.repoDir, ref.URL)
 	}
 	rc := &AsyncRepoCloner{
-		RepoRef:  ref,
-		mutex:    sync.Mutex{},
-		repoPath: repoPath,
+		RepoRef: ref,
+		mutex:   sync.Mutex{},
+		repoDir: repoDir,
 	}
 
 	rs.repositories[ref.URL] = rc

--- a/store.go
+++ b/store.go
@@ -16,7 +16,7 @@ package gitstore
 import (
 	"flag"
 	"fmt"
-	"path"
+	"path/filepath"
 	"sync"
 
 	"github.com/golang/glog"
@@ -93,7 +93,7 @@ func (rs *RepoStore) GetAsync(ref *RepoRef) (*AsyncRepoCloner, <-chan struct{}, 
 
 	var repoDir string
 	if rs.repoDir != "" {
-		repoDir = path.Join(rs.repoDir, ref.URL)
+		repoDir = filepath.Join(rs.repoDir, ref.URL)
 	}
 	rc := &AsyncRepoCloner{
 		RepoRef: ref,

--- a/store.go
+++ b/store.go
@@ -16,6 +16,7 @@ package gitstore
 import (
 	"flag"
 	"fmt"
+	"path"
 	"sync"
 
 	"github.com/golang/glog"
@@ -33,13 +34,15 @@ var (
 type RepoStore struct {
 	repositories map[string]*AsyncRepoCloner
 	mutex        sync.RWMutex
+	repoPath     string
 }
 
 // NewRepoStore initializes a new RepoStore.
-func NewRepoStore() *RepoStore {
+func NewRepoStore(repoPath string) *RepoStore {
 	return &RepoStore{
 		repositories: make(map[string]*AsyncRepoCloner),
 		mutex:        sync.RWMutex{},
+		repoPath:     repoPath,
 	}
 }
 
@@ -88,9 +91,14 @@ func (rs *RepoStore) GetAsync(ref *RepoRef) (*AsyncRepoCloner, <-chan struct{}, 
 		return returnRC(rc)
 	}
 
+	var repoPath string
+	if rs.repoPath != "" {
+		repoPath = path.Join(rs.repoPath, ref.URL)
+	}
 	rc := &AsyncRepoCloner{
-		RepoRef: ref,
-		mutex:   sync.Mutex{},
+		RepoRef:  ref,
+		mutex:    sync.Mutex{},
+		repoPath: repoPath,
 	}
 
 	rs.repositories[ref.URL] = rc

--- a/store_test.go
+++ b/store_test.go
@@ -25,7 +25,7 @@ var _ = Describe("GitStore", func() {
 		var repo *Repo
 
 		BeforeEach(func() {
-			rs = NewRepoStore()
+			rs = NewRepoStore("")
 			var err error
 			repo, err = rs.Get(&RepoRef{
 				URL: repositoryURL,

--- a/store_test.go
+++ b/store_test.go
@@ -16,7 +16,7 @@ package gitstore
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -96,7 +96,7 @@ var _ = Describe("GitStore", func() {
 			})
 
 			It("should clone into a directory in the tmpDir", func() {
-				info, err := os.Stat(path.Join(tmpDir, repositoryURL))
+				info, err := os.Stat(filepath.Join(tmpDir, repositoryURL))
 				Expect(err).To(BeNil())
 				Expect(info.IsDir()).To(BeTrue())
 			})


### PR DESCRIPTION
This change allows users to specify a path in which to clone repositories. If this path is left empty, then the code falls back to cloning in memory (as is the current behaviour)