### PR TITLE
Fix cleaning of non-master branches

### DIFF
--- a/cloner_test.go
+++ b/cloner_test.go
@@ -1,6 +1,10 @@
 package gitstore
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -8,39 +12,83 @@ import (
 )
 
 var _ = Describe("GitStore", func() {
-	var rs *RepoStore
+	var cloneTests = func(path string) {
+		var rs *RepoStore
+		BeforeEach(func() {
+			rs = NewRepoStore(path)
+		})
 
-	BeforeEach(func() {
-		rs = NewRepoStore("")
+		Context("when a new repo is cloned", func() {
+			var repo *Repo
+
+			BeforeEach(func() {
+				var err error
+				repo, err = rs.Get(&RepoRef{
+					URL: repositoryURL,
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should checkout a detached HEAD", func() {
+				ref, err := repo.repository.Head()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ref.Name().String()).ToNot(Equal("refs/heads/master"))
+			})
+
+			It("should have no local branches checked out", func() {
+				cfg, err := repo.repository.Storer.Config()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cfg.Branches).To(BeEmpty())
+			})
+
+			It("refs/heads/master should not be a resolvable reference", func() {
+				ref, err := storer.ResolveReference(repo.repository.Storer, plumbing.ReferenceName("refs/heads/master"))
+				Expect(err).To(HaveOccurred())
+				Expect(ref).To(BeNil())
+			})
+		})
+	}
+
+	Context("(In Memory)", func() {
+		cloneTests("")
 	})
 
-	Context("when a new repo is cloned", func() {
-		var repo *Repo
+	Context("(On Disk)", func() {
+		var tmpDir string
 
 		BeforeEach(func() {
+			// Create a temp directory for each test
 			var err error
-			repo, err = rs.Get(&RepoRef{
-				URL: repositoryURL,
+			tmpDir, err = ioutil.TempDir("", "git-store")
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(tmpDir)
+		})
+
+		cloneTests(tmpDir)
+
+		Context("when cloning a repo to a filesystem", func() {
+			BeforeEach(func() {
+				rs := NewRepoStore(tmpDir)
+				_, err := rs.Get(&RepoRef{
+					URL: repositoryURL,
+				})
+				Expect(err).ToNot(HaveOccurred())
 			})
-			Expect(err).ToNot(HaveOccurred())
-		})
 
-		It("should checkout a detached HEAD", func() {
-			ref, err := repo.repository.Head()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ref.Name().String()).ToNot(Equal("refs/heads/master"))
-		})
+			It("should update the HEAD file in the .git folder to the detached ref", func() {
+				head, err := ioutil.ReadFile(filepath.Join(tmpDir, repositoryURL, ".git", "HEAD"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(head)).ToNot(Equal("ref: refs/heads/master"))
+			})
 
-		It("should have no local branches checked out", func() {
-			cfg, err := repo.repository.Storer.Config()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cfg.Branches).To(BeEmpty())
-		})
-
-		It("refs/heads/master should not be a resolvable reference", func() {
-			ref, err := storer.ResolveReference(repo.repository.Storer, plumbing.ReferenceName("refs/heads/master"))
-			Expect(err).To(HaveOccurred())
-			Expect(ref).To(BeNil())
+			It("should not have any local refs", func() {
+				files, err := ioutil.ReadDir(filepath.Join(tmpDir, repositoryURL, ".git", "refs", "heads"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(files).To(HaveLen(0))
+			})
 		})
 	})
 })

--- a/repo.go
+++ b/repo.go
@@ -111,7 +111,7 @@ func cleanLocalBranches(repo *git.Repository) error {
 	err = branches.ForEach(func(ref *plumbing.Reference) error {
 		if ref.Name().IsBranch() {
 			// This is a locally stored branch
-			branch := strings.TrimLeft(ref.Name().String(), "refs/heads/")
+			branch := strings.TrimPrefix(ref.Name().String(), "refs/heads/")
 			err := repo.DeleteBranch(branch)
 			if err != nil {
 				return fmt.Errorf("error deleting branch %s: %v", ref.Name(), err)


### PR DESCRIPTION
The `TrimLeft` function is not what we wanted 🤦‍♂ I've also added some extra tests for cloning onto the filesystem