### PR TITLE
Open repository if it has already been cloned

### DIFF
--- a/cloner.go
+++ b/cloner.go
@@ -36,6 +36,9 @@ func (rc *AsyncRepoCloner) Clone(auth transport.AuthMethod) <-chan struct{} {
 		var repository *git.Repository
 		if rc.repoDir != "" {
 			repository, err = git.PlainClone(rc.repoDir, false, cloneOptions)
+			if err == git.ErrRepositoryAlreadyExists {
+				repository, err = git.PlainOpen(rc.repoDir)
+			}
 		} else {
 			// No repoDir provided, default to in memory clone
 			fs := memfs.New()

--- a/cloner_test.go
+++ b/cloner_test.go
@@ -123,6 +123,16 @@ var _ = Describe("GitStore", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(files).To(HaveLen(0))
 			})
+
+			It("should be able to do it multiple times", func() {
+				for i := 0; i <= 3; i++ {
+					rs := NewRepoStore(tmpDir)
+					_, err := rs.Get(&RepoRef{
+						URL: repositoryURL,
+					})
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
 		})
 	})
 })


### PR DESCRIPTION
Previously the Cloner would error (with ErrRepositoryAlreadyExists), which obviously isn't that useful. If faced with this specific error we now open the repository instead.