### PR TITLE
[IS-691] Fix linter target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ vet: vendor
 	$(GO) vet ./...
 
 .PHONY: lint
-lint:
+lint: vendor
 	@ echo "$(GREEN)Linting code$(NC)"
 	$(LINTER) run --disable-all \
 		--exclude-use-default=false \

--- a/repo.go
+++ b/repo.go
@@ -16,9 +16,9 @@ package gitstore
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
-	"strings"
 
 	"github.com/gobwas/glob"
 	git "gopkg.in/src-d/go-git.v4"


### PR DESCRIPTION
This fixes the missing vendor dependencies for the `lint` target.